### PR TITLE
Bump node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/sashafklein/ava-describe.git"
   },
   "engines": {
-    "node": "6.2.x"
+    "node": ">=6.2.x"
   },
   "scripts": {
     "test": "ava test --verbose",


### PR DESCRIPTION
>=6.2.0, instead of locked at that minor version.